### PR TITLE
r.URL.Path[1:]对应request结构体中的Act

### DIFF
--- a/apiserver.go
+++ b/apiserver.go
@@ -76,7 +76,7 @@ func (api *apiserver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	resultchan := make(chan Result)
-	req := &request{r.URL.String()[1:], r.FormValue("mobile"), r.FormValue("code"), r.FormValue("service"), r.FormValue("uid"), resultchan}
+	req := &request{r.URL.Path[1:], r.FormValue("mobile"), r.FormValue("code"), r.FormValue("service"), r.FormValue("uid"), resultchan}
 	hash := hashFunc([]byte(req.String())) & uint64(*smsworks-1)
 
 	for {


### PR DESCRIPTION
r.URL.Path[1:]对应request结构体中的Act。不是r.URL.String()[1:]。